### PR TITLE
Improve UI speech feedback

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,4 +1,5 @@
 import { Game } from './game.js';
+import { SpeechManager } from './SpeechManager.js';
 
 // Get the render target div
 const renderDiv = document.getElementById('renderDiv');
@@ -9,4 +10,39 @@ if (!renderDiv) {
 } else {
     // Initialize the game with the render target
     const game = new Game(renderDiv);
+
+    const instructionEl = document.getElementById('instruction-text');
+
+    let activeMode = '';
+    let fadeTimeout = null;
+
+    const showInstruction = (msg) => {
+        if (!instructionEl) return;
+        instructionEl.textContent = msg;
+        instructionEl.style.opacity = '1';
+        if (fadeTimeout) clearTimeout(fadeTimeout);
+        fadeTimeout = setTimeout(() => {
+            instructionEl.style.opacity = '0';
+        }, 2000);
+    };
+
+    const speechManager = new SpeechManager(
+        (finalTranscript, interimTranscript) => {
+            const transcript = finalTranscript ?? interimTranscript ?? '';
+            const modeInfo = activeMode ? `Mode: ${activeMode}` : '';
+            const text = [transcript.trim(), modeInfo].filter(Boolean).join(' - ');
+            if (text) showInstruction(text);
+        },
+        (active) => {
+            if (active) {
+                showInstruction('Listening...');
+            }
+        },
+        (cmd) => {
+            activeMode = cmd;
+            showInstruction(`Mode: ${activeMode}`);
+        }
+    );
+
+    speechManager.requestPermissionAndStart();
 }

--- a/styles.css
+++ b/styles.css
@@ -28,4 +28,6 @@
     color: white;
     border-color: #2574A9;
     box-shadow: 5px 5px 0px #2574A9;
+    pointer-events: none;
+    transition: opacity 0.3s ease-in-out;
 }


### PR DESCRIPTION
## Summary
- update `SpeechManager` callbacks to render speech status and transcripts
- fade transcripts after a short delay for a less intrusive UI

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840a4d198608329a0e320c2b41ed947