### PR TITLE
Integrate SpeechManager for mode switching

### DIFF
--- a/game.js
+++ b/game.js
@@ -24,9 +24,41 @@ export class Game {
         const directionalLight = new THREE.DirectionalLight(0xffffff, 0.5);
         directionalLight.position.set(5, 5, 5);
         this.scene.add(directionalLight);
-        
+
+        // Initial interaction mode
+        this.currentMode = 'drag';
+
+        // Grab instruction text element if it exists
+        this.instructionEl = document.getElementById('instruction-text');
+        this.updateInstruction(`Mode: ${this.currentMode}`);
+
+        // Set up speech manager for voice commands
+        this.speechManager = new SpeechManager(
+            null,
+            null,
+            (cmd) => this.handleVoiceCommand(cmd)
+        );
+        // Begin listening (will request microphone permissions)
+        if (this.speechManager) {
+            this.speechManager.requestPermissionAndStart();
+        }
+    
         // Start animation loop
         this.animate();
+    }
+
+    handleVoiceCommand(command) {
+        const validModes = ['drag', 'rotate', 'scale', 'animate'];
+        if (validModes.includes(command)) {
+            this.currentMode = command;
+            this.updateInstruction(`Mode: ${this.currentMode}`);
+        }
+    }
+
+    updateInstruction(text) {
+        if (this.instructionEl) {
+            this.instructionEl.textContent = text;
+        }
     }
 
     animate = () => {


### PR DESCRIPTION
## Summary
- create SpeechManager instance in `Game`
- update instructions and handle recognized commands
- allow switching between drag/rotate/scale/animate modes

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6840a4cf86c48329892c6c8e73a117b6