### PR TITLE
Load GLTF model on startup

### DIFF
--- a/game.js
+++ b/game.js
@@ -24,6 +24,26 @@ export class Game {
         const directionalLight = new THREE.DirectionalLight(0xffffff, 0.5);
         directionalLight.position.set(5, 5, 5);
         this.scene.add(directionalLight);
+
+        // Text element for displaying load errors if available
+        this.instructionText = document.getElementById('instruction-text');
+
+        // Load the default GLTF model
+        const loader = new GLTFLoader();
+        loader.load(
+            'assets/Stan.gltf',
+            (gltf) => {
+                this.scene.add(gltf.scene);
+            },
+            undefined,
+            (error) => {
+                const message = 'Failed to load assets/Stan.gltf';
+                if (this.instructionText) {
+                    this.instructionText.textContent = message;
+                }
+                console.error(message, error);
+            }
+        );
         
         // Start animation loop
         this.animate();


### PR DESCRIPTION
## Summary
- load `assets/Stan.gltf` when the game starts
- display error message in `instruction-text` on loading failure

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6840a4cb11808329afefb840b9391fc6