### PR TITLE
Add start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,17 @@ git clone https://github.com/collidingScopes/3d-model-playground
 # Navigate to the project directory
 cd 3d-model-playground
 
-# Serve with your preferred method (example using Python)
-python -m http.server
-```
+# Install dependencies
+npm install
 
-Then navigate to `http://localhost:8000` in your browser.
+# Start the development server
+npm run dev
+
+# Build and preview the production version
+npm run build
+npm start
+```
+Then navigate to the address shown in your terminal (http://localhost:5173 for dev or http://localhost:4173 for preview).
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "start": "vite preview"
   },
   "dependencies": {
     "three": "^0.161.0",


### PR DESCRIPTION
## Summary
- add `npm start` script that runs `vite preview`
- update README development instructions

## Testing
- `npm install`
- `npm run build`
- `npm start` *(fails: `press h + enter to show help` - server starts)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6840a4c629c8832984c3b67efeeaed01