### PR TITLE
Update dev instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,19 @@ git clone https://github.com/collidingScopes/3d-model-playground
 # Navigate to the project directory
 cd 3d-model-playground
 
-# Serve with your preferred method (example using Python)
+# Install dependencies
+npm install
+
+# Start the dev server (uses vite)
+npm run dev
+
+# Or serve with your preferred method (example using Python)
 python -m http.server
 ```
 
-Then navigate to `http://localhost:8000` in your browser.
+Then navigate to `http://localhost:8000` or the port printed by `npm run dev` in your browser.
+
+Vite handles the dev/preview server, so any scripts such as `npm run dev` or `npm run preview` rely on it.
 
 ## License
 


### PR DESCRIPTION
## Summary
- add `npm install` and `npm run dev` instructions to README
- explain that Vite handles the dev/preview server

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6840a4c347a48329a55e7e9e700f60c6